### PR TITLE
Export env vars that indicate if cache was hit or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ steps:
           restore:
             - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
           save:
-            - key: 'v1-node-modules-{{ checksum("package-lock.json") }}'
+            - key: 'v1-node-modules-{{ checksum "package-lock.json" }}'
               paths: [ "node_modules" ]
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ steps:
       - peakon/s3-cache#v2.1.3:
           id: CACHE_IDENTIFIER # optional, default: none
           aws_profile: aws-profile-name # optional, default: none
+          restore_dry_run: false # set it to "true" to only check if cacheKey is present on S3 (no download / restoring)
           save:
             - key: 'v1-node-modules-{{ checksum("package-lock.json") }}' # required
               paths: [ "node_modules" ] # required, array of strings
@@ -44,7 +45,7 @@ In some cases you may need to build a conditional logic in the build command bas
 
 To support this use-case, this plugin exports environment variables that can be used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration. 
 
-For example:
+For example, this step generates a cache of `node_modules` (which is then used by all jobs that need it):
 
 ```yml
 steps:
@@ -52,9 +53,13 @@ steps:
     plugins:
       - peakon/s3-cache:
           id: npm
-          restore_dry_run: true 
+          restore_dry_run: true # This saves runtime, but doesn't check for integrity 
           restore:
             - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
+          save:
+            - key: 'v1-node-modules-{{ checksum("package-lock.json") }}'
+              paths: [ "node_modules" ]
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ steps:
   - command: npm install && npm test
     plugins:
       - peakon/s3-cache#v2.1.3:
+          id: CACHE_IDENTIFIER # optional, default: none
+          aws_profile: aws-profile-name # optional, default: none
           save:
             - key: 'v1-node-modules-{{ checksum("package-lock.json") }}' # required
               paths: [ "node_modules" ] # required, array of strings
@@ -35,10 +37,22 @@ Make sure to set `BUILDKITE_PLUGIN_S3_CACHE_BUCKET_NAME=your-cache-bucket-name` 
 
 You can specify either `save` or `restore` or both of them for a single pipeline step.
 
-#### `save` properties
 
+#### Checking if cache was successfully restored
 
-#### `restore` properties
+In some cases there may be a need to build a conditional logic in the build command based on the results of cache restore operation (for example, to avoid re-generating the cache which already exists and was restored successfully).
+To support this use-case, this plugins exports environment variables that can be then used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration. 
+For example:
+
+```yml
+steps:
+  - command: "[ ! \"${BUILDKITE_PLUGIN_S3_CACHE_node_modules_0_KEY_0_HIT}\" =~ ^(true)$ ] && npm install"
+    plugins:
+      - peakon/s3-cache:
+          id: node_modules 
+          restore:
+            - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
+```
 
 
 #### Supported functions

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ steps:
   - command: "[ ! \"${BUILDKITE_PLUGIN_S3_CACHE_npm_0_KEY_0_HIT}\" =~ ^(true)$ ] && npm install"
     plugins:
       - peakon/s3-cache:
-          id: npm 
+          id: npm
+          restore_dry_run: true 
           restore:
             - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
 ```

--- a/README.md
+++ b/README.md
@@ -40,16 +40,18 @@ You can specify either `save` or `restore` or both of them for a single pipeline
 
 #### Checking if cache was successfully restored
 
-In some cases there may be a need to build a conditional logic in the build command based on the results of cache restore operation (for example, to avoid re-generating the cache which already exists and was restored successfully).
-To support this use-case, this plugins exports environment variables that can be then used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration. 
+In some cases you may need to build a conditional logic in the build command based on the results of cache restore operation (for example, to avoid re-generating the cache which already exists and was restored successfully).
+
+To support this use-case, this plugin exports environment variables that can be used during a `command` step. The feature is opt-in and requires `id` to be specified in plugin configuration. 
+
 For example:
 
 ```yml
 steps:
-  - command: "[ ! \"${BUILDKITE_PLUGIN_S3_CACHE_node_modules_0_KEY_0_HIT}\" =~ ^(true)$ ] && npm install"
+  - command: "[ ! \"${BUILDKITE_PLUGIN_S3_CACHE_npm_0_KEY_0_HIT}\" =~ ^(true)$ ] && npm install"
     plugins:
       - peakon/s3-cache:
-          id: node_modules 
+          id: npm 
           restore:
             - keys: [ 'v1-node-modules-{{ checksum "package-lock.json" }}' ]
 ```

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -214,8 +214,14 @@ function restoreCache {
       local cacheKey
       cacheItemKeyTemplateDecoded=$(echo "$cacheItemKeyTemplate" | base64 -d)
       cacheKey=$(getCacheKey "$cacheItemKeyTemplateDecoded")
-      isRestored=$(s3Restore "$cacheKey")
       
+      # Only check if cache exists on S3 if "restore_dry_run: true"
+      if [[ "${BUILDKITE_PLUGIN_S3_CACHE_RESTORE_DRY_RUN:-}" =~ ^(true)$ ]]; then
+        isRestored=$(s3Exists "$key")
+      else
+        isRestored=$(s3Restore "$cacheKey")
+      fi
+
       # Provide information if cache was hit (only if cache has name)
       if [[ -n "${BUILDKITE_PLUGIN_S3_CACHE_ID:-}" ]]; then
         exportEnvVar "BUILDKITE_PLUGIN_S3_CACHE_${BUILDKITE_PLUGIN_S3_CACHE_ID}_${lineNumber}_KEY_${index}_HIT" "${isRestored}"

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -185,6 +185,10 @@ function saveCache {
   done < "$tempFile"
 }
 
+function exportEnvVar {
+  export "$1=$2"
+}
+
 function restoreCache {
   local restoreConfig
   restoreConfig=$(getRestoreConfig)
@@ -196,9 +200,11 @@ function restoreCache {
   local tempFile
   tempFile=$(makeTempFile)
   getCacheItemsForRestore "$restoreConfig" > "$tempFile"
-
+  
+  local lineNumber=0
   while read -r cacheItemKeyTemplates
   do
+    local index=0
     # shellcheck disable=SC2206
     local cacheItemKeysTemplatesArray=($cacheItemKeyTemplates)
     for cacheItemKeyTemplate in "${cacheItemKeysTemplatesArray[@]}"
@@ -209,12 +215,20 @@ function restoreCache {
       cacheItemKeyTemplateDecoded=$(echo "$cacheItemKeyTemplate" | base64 -d)
       cacheKey=$(getCacheKey "$cacheItemKeyTemplateDecoded")
       isRestored=$(s3Restore "$cacheKey")
+      
+      # Provide information if cache was hit (only if cache has name)
+      if [[ -n "${BUILDKITE_PLUGIN_S3_CACHE_ID:-}" ]]; then
+        exportEnvVar "BUILDKITE_PLUGIN_S3_CACHE_${BUILDKITE_PLUGIN_S3_CACHE_ID}_${lineNumber}_KEY_${index}_HIT=${isRestored}"
+      fi
+
       if [[ "$isRestored" == "true" ]]; then
         echo "Successfully restored $cacheKey"
         break
       else
         echo "Failed to restore $cacheKey. The following error occured: ${isRestored}"
       fi
+      ((index+=1))
     done
+    ((lineNumber+=1))
   done < "$tempFile"
 }

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -217,7 +217,7 @@ function restoreCache {
       
       # Only check if cache exists on S3 if "restore_dry_run: true"
       if [[ "${BUILDKITE_PLUGIN_S3_CACHE_RESTORE_DRY_RUN:-}" =~ ^(true)$ ]]; then
-        isRestored=$(s3Exists "$key")
+        isRestored=$(s3Exists "$cacheKey")
       else
         isRestored=$(s3Restore "$cacheKey")
       fi

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -186,7 +186,7 @@ function saveCache {
 }
 
 function exportEnvVar {
-  export "$1"
+  export "$1"="$2"
 }
 
 function restoreCache {
@@ -218,7 +218,7 @@ function restoreCache {
       
       # Provide information if cache was hit (only if cache has name)
       if [[ -n "${BUILDKITE_PLUGIN_S3_CACHE_ID:-}" ]]; then
-        exportEnvVar "BUILDKITE_PLUGIN_S3_CACHE_${BUILDKITE_PLUGIN_S3_CACHE_ID}_${lineNumber}_KEY_${index}_HIT=${isRestored}"
+        exportEnvVar "BUILDKITE_PLUGIN_S3_CACHE_${BUILDKITE_PLUGIN_S3_CACHE_ID}_${lineNumber}_KEY_${index}_HIT" "${isRestored}"
       fi
 
       if [[ "$isRestored" == "true" ]]; then

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -186,7 +186,7 @@ function saveCache {
 }
 
 function exportEnvVar {
-  export "$1=$2"
+  export "$1"
 }
 
 function restoreCache {

--- a/plugin.yml
+++ b/plugin.yml
@@ -13,6 +13,8 @@ configuration:
       type: boolean
     aws_profile:
       type: string
+    id:
+      type: string
     save:
       type: array
       minimum: 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,8 @@ configuration:
       type: string
     id:
       type: string
+    restore_dry_run:
+      type: boolean
     save:
       type: array
       minimum: 1

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -246,7 +246,7 @@ setup() {
   
   restoreCache
 
-  declare -a expected;
+  declare -a expected
   expected+="BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_0_HIT=false"
   expected+="BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_0_KEY_1_HIT=true"
   expected+="BUILDKITE_PLUGIN_S3_CACHE_FOO_BAR_1_KEY_0_HIT=true"

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -195,7 +195,7 @@ setup() {
 
   function s3Restore { echo "true"; }
   function exportEnvVar {
-    exportedEnvironment+="$1"
+    exportedEnvironment+="$1=$2"
   }
   export -f s3Restore
   export -f exportEnvVar
@@ -214,7 +214,7 @@ setup() {
 
   function s3Restore { echo "false"; }
   function exportEnvVar {
-    exportedEnvironment+="$1"
+    exportedEnvironment+="$1=$2"
   }
   export -f s3Restore
   export -f exportEnvVar
@@ -239,7 +239,7 @@ setup() {
     fi
   }
   function exportEnvVar {
-    exportedEnvironment+="$1"
+    exportedEnvironment+="$1=$2"
   }
   export -f s3Restore
   export -f exportEnvVar


### PR DESCRIPTION
1. Export env vars to wllow conditional execution of scripts (e.g. `yarn install` during the build, based on the result of `s3 cache restore`.
2. Added `restore_dry_run` boolean option (default: false), to skip download/restore of cache from S3 (just checks if cacheKey is present on S3)