### PR TITLE
Do not upload an empty tarball

### DIFF
--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -96,12 +96,14 @@ function s3Exists {
 function s3Upload {
   local s3_path
   local localPaths
+  local tempFile
   s3_path=$(s3Path "$1")
   # shellcheck disable=SC2206
   localPaths=($2)
+  tempFile=$(makeTempFile)
   set +e
   # shellcheck disable=SC2068
-  if ! (tar -czf /tmp/file.tar.gz ${localPaths[@]} && aws "${aws_cli_args[@]}" s3 cp /tmp/file.tar.gz "$s3_path"); then
+  if ! (tar -czf "$tempFile" ${localPaths[@]} && aws "${aws_cli_args[@]}" s3 cp "$tempFile" "$s3_path" --quiet); then
     echo "false"
   else
     echo "true"

--- a/lib/functions.bash
+++ b/lib/functions.bash
@@ -101,7 +101,7 @@ function s3Upload {
   localPaths=($2)
   set +e
   # shellcheck disable=SC2068
-  if ! (tar --ignore-failed-read -cz ${localPaths[@]} | aws "${aws_cli_args[@]}" s3 cp - "$s3_path"); then
+  if ! (tar -czf /tmp/file.tar.gz ${localPaths[@]} && aws "${aws_cli_args[@]}" s3 cp /tmp/file.tar.gz "$s3_path"); then
     echo "false"
   else
     echo "true"

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -327,18 +327,21 @@ setup() {
   unset BUILDKITE_PLUGIN_S3_CACHE_PIPELINE_NAME
 }
 
-@test "s3Upload with existing and nont-existing paths" {
+@test "s3Upload with existing and non-existing paths" {
+  makeTempFile() { echo /tmp/file.tar.gz; }
+  export -f makeTempFile
   stub aws \
-    "s3 cp /tmp/file.tar.gz s3://bucket/my-org/my-pipeline/s3_path.tar.gz : :"
+    "s3 cp /tmp/file.tar.gz s3://bucket/my-org/my-pipeline/s3_path.tar.gz --quiet : :"
   stub tar \
     "-czf /tmp/file.tar.gz local_paths : :" \
-     "-czf /tmp/file.tar.gz local_paths : exit 1"
+    "-czf /tmp/file.tar.gz local_paths : exit 1"
 
   run -0 s3Upload s3_path local_paths
   assert_output "true"
   run -0 s3Upload s3_path local_paths
   assert_output "false"
 
+  unset makeTempFile
   unstub aws
   unstub tar
 }

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -324,4 +324,21 @@ setup() {
   export BUILDKITE_PLUGIN_S3_CACHE_PIPELINE_NAME="another-pipeline"
   run -0 s3ObjectKey file
   assert_output "my-org/another-pipeline/file.tar.gz"
+  unset BUILDKITE_PLUGIN_S3_CACHE_PIPELINE_NAME
+}
+
+@test "s3Upload with existing and nont-existing paths" {
+  stub aws \
+    "s3 cp /tmp/file.tar.gz s3://bucket/my-org/my-pipeline/s3_path.tar.gz : :"
+  stub tar \
+    "-czf /tmp/file.tar.gz local_paths : :" \
+     "-czf /tmp/file.tar.gz local_paths : exit 1"
+
+  run -0 s3Upload s3_path local_paths
+  assert_output "true"
+  run -0 s3Upload s3_path local_paths
+  assert_output "false"
+
+  unstub aws
+  unstub tar
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -11,6 +11,7 @@ function cleanup {
 trap cleanup EXIT
 
 setup() {
+  bats_require_minimum_version 1.5.0
   export BUILDKITE_BUILD_CHECKOUT_PATH=$tmp_dir
   export BUILDKITE_BUILD_ID=1
   export BUILDKITE_JOB_ID=0
@@ -21,6 +22,5 @@ setup() {
 
 @test "Post-command succeeds" {
   export BUILDKITE_PLUGIN_S3_CACHE_SAVE_0_KEY=v1-node-modules
-  run "$post_command_hook"
-  assert_success
+  run -0 "$post_command_hook"
 }

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -11,6 +11,7 @@ function cleanup {
 trap cleanup EXIT
 
 setup() {
+  bats_require_minimum_version 1.5.0
   export BUILDKITE_BUILD_CHECKOUT_PATH=$tmp_dir
   export BUILDKITE_BUILD_ID=1
   export BUILDKITE_JOB_ID=0
@@ -35,7 +36,6 @@ function teardown() {
 
   run "$pre_command_hook"
 
-  assert_success
   assert_output --partial "Successfully restored v1-cache-key"
 }
 
@@ -50,9 +50,8 @@ function teardown() {
     "-xz : echo true" \
     "-xz : echo true"
 
-  run "$pre_command_hook"
+  run -0 "$pre_command_hook"
 
-  assert_success
   assert_output --partial "Failed to restore cache-key-missing"
   assert_output --partial "Successfully restored cache-key-exists"
 }


### PR DESCRIPTION
## Change

Make sure we do not upload an empty tarball to S3.

Example build when `node_modules` folder doesn't exist: https://buildkite.com/peakon/backoffice-browser-tests/builds/532#018875e0-be0d-4b57-b05b-fd5707ca50d0/329-334
```
Uploading new cache for key: v2-node-modules-c81a986317355c12556a1aad2700cfb046285f61
tar: node_modules: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
Failed to upload new cache for key: v2-node-modules-c81a986317355c12556a1aad2700cfb046285f61
```

## Problem / Why

There's bug in the plugin where when `tar -cz ...` fails, for instance when we have a non-existing path, since we are using `--ignore-failed-read` we end up creating and uploading an empty tarball.

Example build when `node_modules` folder doesn't exist: 
https://buildkite.com/peakon/backoffice/builds/3230#018875d5-f91c-4714-b961-a1deec8f2fb0/383-388
```
Uploading new cache for key: v2-node-modules-c81a986317355c12556a1aad2700cfb046285f61
tar: node_modules: Warning: Cannot stat: No such file or directory
Uploaded new cache for key: v2-node-modules-c81a986317355c12556a1aad2700cfb046285f61
```
Here we uploaded an empty tarball 🐛 

## References

- https://workday-dev.slack.com/archives/C01TN7LUFNE/p1685131491039969
